### PR TITLE
Fix inline style string

### DIFF
--- a/src/styleq.js
+++ b/src/styleq.js
@@ -123,28 +123,34 @@ function createStyleq(options?: StyleqOptions): Styleq {
 
       // ----- DYNAMIC: Process inline style object -----
       else {
-        for (const prop in style) {
-          const value = style[prop];
-          if (value !== undefined) {
-            if (disableMix) {
-              if (inlineStyle == null) {
-                inlineStyle = {};
-              }
-              // Only set the value if it hasn't already been set
-              if (inlineStyle[prop] === undefined) {
-                inlineStyle[prop] = value;
-              }
-            } else if (!definedProperties.includes(prop)) {
-              if (value != null) {
-                if (inlineStyle == null) {
-                  inlineStyle = {};
+        if (disableMix) {
+          if (inlineStyle == null) {
+            inlineStyle = {};
+          }
+          inlineStyle = Object.assign({}, style, inlineStyle);
+        } else {
+          let subStyle = null;
+          for (const prop in style) {
+            const value = style[prop];
+            if (value !== undefined) {
+              if (!definedProperties.includes(prop)) {
+                if (value != null) {
+                  if (inlineStyle == null) {
+                    inlineStyle = {};
+                  }
+                  if (subStyle == null) {
+                    subStyle = {};
+                  }
+                  subStyle[prop] = value;
                 }
-                inlineStyle[prop] = value;
+                definedProperties.push(prop);
+                // Cache is unnecessary overhead if results can't be reused.
+                nextCache = null;
               }
-              definedProperties.push(prop);
-              // Cache is unnecessary overhead if results can't be reused.
-              nextCache = null;
             }
+          }
+          if (subStyle != null) {
+            inlineStyle = Object.assign(subStyle, inlineStyle);
           }
         }
       }

--- a/src/transform-localize-style.js
+++ b/src/transform-localize-style.js
@@ -20,7 +20,7 @@ const markerProp = '$$css$localize';
  * => { float: 'float-left' }
  */
 
-function compileStyle(style, isRTL: boolean) {
+function compileStyle(style, isRTL) {
   // Create a new compiled style for styleq
   const compiledStyle = {};
   for (const prop in style) {
@@ -36,7 +36,7 @@ function compileStyle(style, isRTL: boolean) {
   return compiledStyle;
 }
 
-export function localizeStyle(style, isRTL: boolean) {
+export function localizeStyle(style, isRTL) {
   if (style[markerProp] != null) {
     const compiledStyleIndex = isRTL ? 1 : 0;
     // Check the cache in case we've already seen this object

--- a/src/transform-localize-style.js
+++ b/src/transform-localize-style.js
@@ -20,7 +20,7 @@ const markerProp = '$$css$localize';
  * => { float: 'float-left' }
  */
 
-function compileStyle(style, isRTL) {
+function compileStyle(style, isRTL: boolean) {
   // Create a new compiled style for styleq
   const compiledStyle = {};
   for (const prop in style) {
@@ -36,7 +36,7 @@ function compileStyle(style, isRTL) {
   return compiledStyle;
 }
 
-export function localizeStyle(style, isRTL) {
+export function localizeStyle(style, isRTL: boolean) {
   if (style[markerProp] != null) {
     const compiledStyleIndex = isRTL ? 1 : 0;
     // Check the cache in case we've already seen this object

--- a/styleq.flow.js
+++ b/styleq.flow.js
@@ -19,13 +19,13 @@ type InlineStyle = {
 type EitherStyle = CompiledStyle | InlineStyle;
 
 export type StylesArray<+T> = T | $ReadOnlyArray<StylesArray<T>>;
-export type Styles = StylesArray<CompiledStyle | InlineStyle | false>;
+export type Styles = StylesArray<EitherStyle | false | void>;
 export type Style<+T = EitherStyle> = StylesArray<false | ?T>;
 
 export type StyleqOptions = {
   disableCache?: boolean,
   disableMix?: boolean,
-  transform?: (CompiledStyle) => CompiledStyle,
+  transform?: (EitherStyle) => EitherStyle,
 };
 
 export type StyleqResult = [string, InlineStyle | null];

--- a/styleq.flow.js
+++ b/styleq.flow.js
@@ -7,16 +7,16 @@
  * @flow strict
  */
 
-type CompiledStyle = {
+export type CompiledStyle = {
   $$css: boolean,
   [key: string]: string,
 };
 
-type InlineStyle = {
-  [key: string]: mixed,
+export type InlineStyle = {
+  [key: string]: number | string,
 };
 
-type EitherStyle = CompiledStyle | InlineStyle;
+export type EitherStyle = CompiledStyle | InlineStyle;
 
 export type StylesArray<+T> = T | $ReadOnlyArray<StylesArray<T>>;
 export type Styles = StylesArray<EitherStyle | false | void>;

--- a/test/benchmark.node.js
+++ b/test/benchmark.node.js
@@ -87,6 +87,7 @@ jsonReporter(suite);
  */
 
 const styleqNoCache = styleq.factory({ disableCache: true });
+const styleqNoMix = styleq.factory({ disableMix: true });
 const styleqWithLocalization = styleq.factory({
   transform(style) {
     return localizeStyle(style, false);
@@ -288,6 +289,37 @@ test('large inline style', () => {
 
 test('merged inline style', () => {
   styleq(
+    {
+      backgroundColor: 'blue',
+      borderColor: 'blue',
+      display: 'block',
+    },
+    {
+      backgroundColor: 'red',
+      borderColor: 'red',
+      borderStyle: 'solid',
+      borderWidth: '1px',
+      boxSizing: 'border-bx',
+      display: 'flex',
+      listStyle: 'none',
+      marginTop: '0',
+      marginEnd: '0',
+      marginBottom: '0',
+      marginStart: '0',
+      paddingTop: '0',
+      paddingEnd: '0',
+      paddingBottom: '0',
+      paddingStart: '0',
+      textAlign: 'start',
+      textDecoration: 'none',
+      whiteSpace: 'pre',
+      zIndex: '0',
+    }
+  );
+});
+
+test('merged inline style (mix disabled)', () => {
+  styleqNoMix(
     {
       backgroundColor: 'blue',
       borderColor: 'blue',

--- a/test/styleq.test.js
+++ b/test/styleq.test.js
@@ -12,6 +12,15 @@ import { styleq } from '../src/styleq';
 const styleqNoCache = styleq.factory({ disableCache: true });
 const styleqNoMix = styleq.factory({ disableMix: true });
 
+function stringifyInlineStyle(inlineStyle) {
+  let str = '';
+  Object.keys(inlineStyle).forEach((prop) => {
+    const value = inlineStyle[prop];
+    str += `${prop}:${value};`;
+  });
+  return str;
+}
+
 describe('styleq()', () => {
   test('warns if extracted property values are not strings', () => {
     const err = console.error;
@@ -166,6 +175,16 @@ describe('styleq()', () => {
     expect(inlineStyle2).toEqual(null);
   });
 
+  test('preserves order of inline style', () => {
+    const [, inlineStyle] = styleq([{ font: 'inherit', fontSize: 12 }]);
+    const str = stringifyInlineStyle(inlineStyle);
+    expect(str).toMatchInlineSnapshot(`"font:inherit;fontSize:12;"`);
+
+    const [, inlineStyle2] = styleq([{ font: 'inherit' }, { fontSize: 12 }]);
+    const str2 = stringifyInlineStyle(inlineStyle2);
+    expect(str2).toMatchInlineSnapshot(`"font:inherit;fontSize:12;"`);
+  });
+
   test('dedupes class names and inline styles', () => {
     const a = { $$css: true, a: 'a', ':focus$a': 'focus$a' };
     const b = { $$css: true, b: 'b' };
@@ -190,6 +209,19 @@ describe('styleq()', () => {
     expect(inlineStyle).toEqual({ a: 'aa' });
     const [, inlineStyle2] = styleqNoMix([{ a: 'a' }, { a: null }]);
     expect(inlineStyle2).toEqual({ a: null });
+  });
+
+  test('disableMix preserves stringified order of inline style', () => {
+    const [, inlineStyle] = styleqNoMix([{ font: 'inherit', fontSize: 12 }]);
+    const str = stringifyInlineStyle(inlineStyle);
+    expect(str).toMatchInlineSnapshot(`"font:inherit;fontSize:12;"`);
+
+    const [, inlineStyle2] = styleqNoMix([
+      { font: 'inherit' },
+      { fontSize: 12 },
+    ]);
+    const str2 = stringifyInlineStyle(inlineStyle2);
+    expect(str2).toMatchInlineSnapshot(`"font:inherit;fontSize:12;"`);
   });
 
   test('disableMix does not dedupe class names and inline styles', () => {


### PR DESCRIPTION
Preserve the authored order of inline styles to ensure correct property order when iterating over keys and when producing a string representation.

Fix #3