### PR TITLE
When merging objects, even keys for invalid values should be remembered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "styleq",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "styleq",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.13.10",

--- a/src/styleq.js
+++ b/src/styleq.js
@@ -81,21 +81,23 @@ function createStyleq(options?: StyleqOptions): Styleq {
           for (const prop in style) {
             const value = style[prop];
             if (prop === compiledKey) continue;
-            // Each property value is used as an HTML class name
-            // { 'debug.string': 'debug.string', opacity: 's-jskmnoqp' }
-            if (typeof value === 'string') {
-              // Only add to chunks if this property hasn't already been seen
-              if (!definedProperties.includes(prop)) {
+            // Only add to chunks if this property hasn't already been seen
+            if (!definedProperties.includes(prop)) {
+              // Each property value is used as an HTML class name
+              // { 'debug.string': 'debug.string', opacity: 's-jskmnoqp' }
+              if (typeof value === 'string') {
                 classNameChunk += classNameChunk ? ' ' + value : value;
                 definedProperties.push(prop);
                 if (nextCache != null) {
                   definedPropertiesChunk.push(prop);
                 }
               }
-            }
-            // If we encounter a value that isn't a string
-            else {
-              console.error(`styleq: ${prop} typeof ${value} is not "string".`);
+              // If we encounter a value that isn't a string
+              else if (value !== null) {
+                console.error(
+                  `styleq: ${prop} typeof ${value} is not "string".`
+                );
+              }
             }
           }
           // Cache: write

--- a/src/styleq.js
+++ b/src/styleq.js
@@ -81,23 +81,27 @@ function createStyleq(options?: StyleqOptions): Styleq {
           for (const prop in style) {
             const value = style[prop];
             if (prop === compiledKey) continue;
-            // Only add to chunks if this property hasn't already been seen
-            if (!definedProperties.includes(prop)) {
-              // Each property value is used as an HTML class name
-              // { 'debug.string': 'debug.string', opacity: 's-jskmnoqp' }
-              if (typeof value === 'string') {
-                classNameChunk += classNameChunk ? ' ' + value : value;
+            // Each property value is used as an HTML class name
+            // { 'debug.string': 'debug.string', opacity: 's-jskmnoqp' }
+            if (typeof value === 'string' || value === null) {
+              // Only add to chunks if this property hasn't already been seen
+              if (!definedProperties.includes(prop)) {
                 definedProperties.push(prop);
                 if (nextCache != null) {
                   definedPropertiesChunk.push(prop);
                 }
+                if (typeof value === 'string') {
+                  classNameChunk += classNameChunk ? ' ' + value : value;
+                }
               }
-              // If we encounter a value that isn't a string
-              else if (value !== null) {
-                console.error(
-                  `styleq: ${prop} typeof ${value} is not "string".`
-                );
-              }
+            }
+            // If we encounter a value that isn't a string or `null`
+            else {
+              console.error(
+                `styleq: ${prop} typeof ${String(
+                  value
+                )} is not "string" or "null".`
+              );
             }
           }
           // Cache: write

--- a/test/styleq.test.js
+++ b/test/styleq.test.js
@@ -38,12 +38,36 @@ describe('styleq()', () => {
     expect(styleq(style)[0]).toBe('aaa bbb');
   });
 
+  test('Ignored null and invalid values.', () => {
+    const style = {
+      $$css: true,
+      a: 'aaa',
+      b: 'bbb',
+      c: 1,
+      d: null,
+      e: undefined,
+      f: false,
+      g: true,
+      h: new Date(),
+    };
+    expect(styleqNoCache(style)[0]).toBe('aaa bbb');
+    expect(styleq(style)[0]).toBe('aaa bbb');
+  });
+
   test('combines different class names in order', () => {
     const a = { $$css: true, a: 'a', ':focus$aa': 'focus$aa' };
     const b = { $$css: true, b: 'b' };
     const c = { $$css: true, c: 'c', ':focus$cc': 'focus$cc' };
     expect(styleqNoCache([a, b, c])[0]).toBe('a focus$aa b c focus$cc');
     expect(styleq([a, b, c])[0]).toBe('a focus$aa b c focus$cc');
+  });
+
+  test('Unsets "null" values', () => {
+    const a = { $$css: true, a: 'a', ':focus$aa': 'focus$aa' };
+    const b = { $$css: true, a: null, b: 'b' };
+    const c = { $$css: true, b: null, c: 'c', ':focus$cc': 'focus$cc' };
+    expect(styleqNoCache([a, b, c])[0]).toBe('focus$aa c focus$cc');
+    expect(styleq([a, b, c])[0]).toBe('focus$aa c focus$cc');
   });
 
   test('dedupes class names for the same key', () => {


### PR DESCRIPTION
The primary reason for this change is to support `null` values within compiled style objects.

In addition to that, *any* invalid value should also override previous values for that key. AFAIK, this is what React Native does. (Hard to say for sure since some invalid values will often throw an error).