### PR TITLE
incompatible cache fix

### DIFF
--- a/src/styleq.js
+++ b/src/styleq.js
@@ -20,7 +20,6 @@ import type {
 
 type Cache = WeakMap<CompiledStyle, [string, Array<string>, Cache]>;
 
-const cache: Cache = new WeakMap();
 const compiledKey: '$$css' = '$$css';
 
 function createStyleq(options?: StyleqOptions): Styleq {
@@ -33,6 +32,8 @@ function createStyleq(options?: StyleqOptions): Styleq {
     disableMix = options.disableMix === true;
     transform = options.transform;
   }
+
+  const cache: Cache = new WeakMap();
 
   return function styleq() {
     // Keep track of property commits to the className


### PR DESCRIPTION
Another small change. This basically is a fix for the edge-case where there might be multiple instances of `styleq` being used with different configuration options.