### PR TITLE
feat: Add the ability to override additional props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -628,14 +628,14 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-class-static-block": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.26.0.tgz",
+      "integrity": "sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2504,6 +2504,59 @@
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -6450,6 +6503,37 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -7114,15 +7198,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      }
-    },
-    "@babel/plugin-syntax-private-property-in-object": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-syntax-top-level-await": {
@@ -8222,6 +8297,45 @@
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
       }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
@@ -10974,6 +11088,16 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "dev": true
+    },
+    "update-browserslist-db": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
+      }
     },
     "update-browserslist-db": {
       "version": "1.1.1",

--- a/src/styleq.js
+++ b/src/styleq.js
@@ -27,11 +27,13 @@ function createStyleq(options?: StyleqOptions): Styleq {
   let disableCache;
   let disableMix;
   let transform;
+  let transformProperty;
 
   if (options != null) {
     disableCache = options.disableCache === true;
     disableMix = options.disableMix === true;
     transform = options.transform;
+    transformProperty = options.transformProperty;
   }
 
   return function styleq() {
@@ -95,9 +97,21 @@ function createStyleq(options?: StyleqOptions): Styleq {
             if (typeof value === 'string' || value === null) {
               // Only add to chunks if this property hasn't already been seen
               if (!definedProperties.includes(prop)) {
-                definedProperties.push(prop);
+                const propsToDefine = transformProperty
+                  ? transformProperty(prop)
+                  : prop;
+                const propsIsArray = Array.isArray(propsToDefine);
+                if (propsIsArray) {
+                  definedProperties.push(...propsToDefine);
+                } else {
+                  definedProperties.push(propsToDefine);
+                }
                 if (nextCache != null) {
-                  definedPropertiesChunk.push(prop);
+                  if (propsIsArray) {
+                    definedPropertiesChunk.push(...propsToDefine);
+                  } else {
+                    definedPropertiesChunk.push(propsToDefine);
+                  }
                 }
                 if (typeof value === 'string') {
                   classNameChunk += classNameChunk ? ' ' + value : value;
@@ -158,7 +172,14 @@ function createStyleq(options?: StyleqOptions): Styleq {
                   }
                   (subStyle as InlineStyle)[prop] = value;
                 }
-                definedProperties.push(prop);
+                const propsToDefine = transformProperty
+                  ? transformProperty(prop)
+                  : prop;
+                if (Array.isArray(propsToDefine)) {
+                  definedProperties.push(...propsToDefine);
+                } else {
+                  definedProperties.push(propsToDefine);
+                }
                 // Cache is unnecessary overhead if results can't be reused.
                 nextCache = null;
               }

--- a/src/styleq.js
+++ b/src/styleq.js
@@ -18,7 +18,7 @@ import type {
   Styles
 } from '../styleq.js.flow';
 
-type Cache = WeakMap<CompiledStyle, [string, Array<string>, Cache]>;
+type Cache = WeakMap<CompiledStyle, [string, $ReadOnlyArray<string>, Cache]>;
 
 const cache: Cache = new WeakMap();
 const compiledKey: '$$css' = '$$css';
@@ -78,8 +78,8 @@ function createStyleq(options?: StyleqOptions): Styleq {
           const cacheEntry = nextCache.get(style);
           if (cacheEntry != null) {
             classNameChunk = cacheEntry[0];
-            // $FlowIgnore[method-unbinding]
-            definedProperties.push.apply(definedProperties, cacheEntry[1]);
+            // Note: Babel transforms this into the faster `.apply()`
+            definedProperties.push(...cacheEntry[1]);
             nextCache = cacheEntry[2];
           }
         }
@@ -144,7 +144,7 @@ function createStyleq(options?: StyleqOptions): Styleq {
           }
           inlineStyle = Object.assign({} as InlineStyle, style, inlineStyle);
         } else {
-          let subStyle: null | InlineStyle = null;
+          let subStyle: null | { ...InlineStyle } = null;
           for (const prop in style) {
             const value = style[prop];
             if (value !== undefined) {

--- a/src/styleq.js
+++ b/src/styleq.js
@@ -78,7 +78,7 @@ function createStyleq(options?: StyleqOptions): Styleq {
           const cacheEntry = nextCache.get(style);
           if (cacheEntry != null) {
             classNameChunk = cacheEntry[0];
-            // $FlowIgnore
+            // $FlowIgnore[method-unbinding]
             definedProperties.push.apply(definedProperties, cacheEntry[1]);
             nextCache = cacheEntry[2];
           }

--- a/src/styleq.js
+++ b/src/styleq.js
@@ -100,14 +100,13 @@ function createStyleq(options?: StyleqOptions): Styleq {
                 const propsToDefine = transformProperty
                   ? transformProperty(prop)
                   : prop;
-                const propsIsArray = Array.isArray(propsToDefine);
-                if (propsIsArray) {
+                if (Array.isArray(propsToDefine)) {
                   definedProperties.push(...propsToDefine);
                 } else {
                   definedProperties.push(propsToDefine);
                 }
                 if (nextCache != null) {
-                  if (propsIsArray) {
+                  if (Array.isArray(propsToDefine)) {
                     definedPropertiesChunk.push(...propsToDefine);
                   } else {
                     definedPropertiesChunk.push(propsToDefine);

--- a/styleq.js.flow
+++ b/styleq.js.flow
@@ -27,7 +27,7 @@ export type StyleqOptions = {
   disableCache?: boolean,
   disableMix?: boolean,
   transform?: (EitherStyle) => EitherStyle,
-  transformProperty?: (string) => $ReadOnlyArray<string>,
+  transformProperty?: (string) => $ReadOnlyArray<string> | string,
 };
 
 export type StyleqResult = [string, InlineStyle | null];

--- a/styleq.js.flow
+++ b/styleq.js.flow
@@ -7,15 +7,15 @@
  * @flow strict
  */
 
-export type CompiledStyle = {
+export type CompiledStyle = $ReadOnly<{
   $$css: true,
   [key: string]: string,
-};
+}>;
 
-export type InlineStyle = {
+export type InlineStyle = $ReadOnly<{
   $$css?: empty,
-  [key: string]: number | string,
-};
+  [key: string]: mixed,
+}>;
 
 export type EitherStyle = CompiledStyle | InlineStyle;
 

--- a/styleq.js.flow
+++ b/styleq.js.flow
@@ -27,6 +27,7 @@ export type StyleqOptions = {
   disableCache?: boolean,
   disableMix?: boolean,
   transform?: (EitherStyle) => EitherStyle,
+  transformProperty?: (string) => $ReadOnlyArray<string>,
 };
 
 export type StyleqResult = [string, InlineStyle | null];

--- a/test/transform-properties-style.test.js
+++ b/test/transform-properties-style.test.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Nicolas Gallagher
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { styleq } from '../src/styleq';
+
+const propMap = {
+  marginInlineStart: ['marginInlineStart', 'marginLeft', 'marginRight'],
+  marginInlineEnd: ['marginInlineEnd', 'marginRight', 'marginLeft'],
+  paddingInlineStart: ['paddingInlineStart', 'paddingLeft', 'paddingRight'],
+  paddingInlineEnd: ['paddingInlineEnd', 'paddingRight', 'paddingLeft'],
+  marginLeft: ['marginLeft', 'marginInlineStart', 'marginInlineEnd'],
+  marginRight: ['marginRight', 'marginInlineEnd', 'marginInlineStart'],
+  paddingLeft: ['paddingLeft', 'paddingInlineStart', 'paddingInlineEnd'],
+  paddingRight: ['paddingRight', 'paddingInlineEnd', 'paddingInlineStart'],
+};
+
+const transformProperty = (property) => propMap[property] || property;
+
+const styleqWithPropExpansion = styleq.factory({ transformProperty });
+
+const fixtureLogical = {
+  $$css: true,
+  marginInlineStart: 'margin-start-0px',
+  marginInlineEnd: 'margin-end-10px',
+};
+
+const fixturePhysical = {
+  $$css: true,
+  marginLeft: 'margin-left-4px',
+  marginRight: 'margin-right-8px',
+};
+
+describe('transform: prop overrides', () => {
+  test('physical overrides logical', () => {
+    const [className, style] = styleqWithPropExpansion(fixtureLogical, {
+      $$css: true,
+      marginLeft: 'margin-left-4px',
+    });
+    expect(className).toEqual('margin-left-4px');
+    expect(style).toEqual(null);
+  });
+
+  test('logical overrides physical', () => {
+    const [className, style] = styleqWithPropExpansion(fixturePhysical, {
+      $$css: true,
+      marginInlineStart: 'margin-start-0px',
+    });
+    expect(className).toEqual('margin-start-0px');
+    expect(style).toEqual(null);
+  });
+
+  test('inline styles override too', () => {
+    const [className, style] = styleqWithPropExpansion(fixturePhysical, {
+      marginInlineStart: 4,
+    });
+    expect(className).toEqual('');
+    expect(style).toEqual({ marginInlineStart: 4 });
+  });
+});


### PR DESCRIPTION
This change allows an additional function to be passed into `styleq.factory` that transforms an individual prop key, to return one or more prop keys that should be marked as "defined".

This will unblock a big optimization within StyleX and will allow us to unify the compiler for different "merge configurations".

---

The main purpose of this PR is to be able to remove all the `null` values that are generated in StyleX. 
- One example is to cleanly switch between logical and physical properties
- Another example is a shorthand overriding all it's constituent properties

### Why doesn't the existing `transform` function work?

It works, but it's more expensive than this approach since it would need to run on each object create many more intermediate objects.