### PR TITLE
Add 'transformProperty' feature

### DIFF
--- a/benchmark/performance.js
+++ b/benchmark/performance.js
@@ -110,9 +110,26 @@ const transform = (style) => {
   return flexStyle;
 };
 
+const propMap = {
+  marginInlineStart: ['marginInlineStart', 'marginLeft', 'marginRight'],
+  marginInlineEnd: ['marginInlineEnd', 'marginRight', 'marginLeft'],
+  paddingInlineStart: ['paddingInlineStart', 'paddingLeft', 'paddingRight'],
+  paddingInlineEnd: ['paddingInlineEnd', 'paddingRight', 'paddingLeft'],
+  marginLeft: ['marginLeft', 'marginInlineStart', 'marginInlineEnd'],
+  marginRight: ['marginRight', 'marginInlineEnd', 'marginInlineStart'],
+  paddingLeft: ['paddingLeft', 'paddingInlineStart', 'paddingInlineEnd'],
+  paddingRight: ['paddingRight', 'paddingInlineEnd', 'paddingInlineStart']
+};
+const transformProperty = (property) => propMap[property] || property;
+
 const styleqNoCache = styleq.factory({ disableCache: true });
 const styleqNoMix = styleq.factory({ disableMix: true });
 const styleqTransform = styleq.factory({ transform });
+const styleqTransformProperty = styleq.factory({ transformProperty });
+const styleqTransformPropertyNoCache = styleq.factory({
+  disableCache: true,
+  transformProperty
+});
 
 /**
  * Fixtures
@@ -287,6 +304,14 @@ test('large merge (cache disabled)', () => {
 
 test('large merge (transform)', () => {
   styleqTransform([complexNestedStyleFixture]);
+});
+
+test('large merge (transformProperty)', () => {
+  styleqTransformProperty([complexNestedStyleFixture]);
+});
+
+test('large merge (transformProperty, cache disabled)', () => {
+  styleqTransformPropertyNoCache([complexNestedStyleFixture]);
 });
 
 // INLINE STYLES

--- a/src/styleq.js
+++ b/src/styleq.js
@@ -97,18 +97,23 @@ function createStyleq(options?: StyleqOptions): Styleq {
             if (typeof value === 'string' || value === null) {
               // Only add to chunks if this property hasn't already been seen
               if (!definedProperties.includes(prop)) {
-                const propsToDefine = transformProperty
-                  ? transformProperty(prop)
-                  : prop;
-                if (Array.isArray(propsToDefine)) {
-                  definedProperties.push(...propsToDefine);
-                  if (nextCache != null) {
-                    definedPropertiesChunk.push(...propsToDefine);
+                if (transformProperty) {
+                  const propsToDefine = transformProperty(prop);
+                  if (Array.isArray(propsToDefine)) {
+                    definedProperties.push(...propsToDefine);
+                    if (nextCache != null) {
+                      definedPropertiesChunk.push(...propsToDefine);
+                    }
+                  } else {
+                    definedProperties.push(propsToDefine);
+                    if (nextCache != null) {
+                      definedPropertiesChunk.push(propsToDefine);
+                    }
                   }
                 } else {
-                  definedProperties.push(propsToDefine);
+                  definedProperties.push(prop);
                   if (nextCache != null) {
-                    definedPropertiesChunk.push(propsToDefine);
+                    definedPropertiesChunk.push(prop);
                   }
                 }
                 if (typeof value === 'string') {
@@ -174,13 +179,15 @@ function createStyleq(options?: StyleqOptions): Styleq {
                   }
                   (subStyle as { ...InlineStyle })[prop] = value;
                 }
-                const propsToDefine = transformProperty
-                  ? transformProperty(prop)
-                  : prop;
-                if (Array.isArray(propsToDefine)) {
-                  definedProperties.push(...propsToDefine);
+                if (transformProperty) {
+                  const propsToDefine = transformProperty(prop);
+                  if (Array.isArray(propsToDefine)) {
+                    definedProperties.push(...propsToDefine);
+                  } else {
+                    definedProperties.push(propsToDefine);
+                  }
                 } else {
-                  definedProperties.push(propsToDefine);
+                  definedProperties.push(prop);
                 }
                 // Cache is unnecessary overhead if results can't be reused.
                 nextCache = null;

--- a/src/styleq.js
+++ b/src/styleq.js
@@ -27,11 +27,13 @@ function createStyleq(options?: StyleqOptions): Styleq {
   let disableCache;
   let disableMix;
   let transform;
+  let transformProperty;
 
   if (options != null) {
     disableCache = options.disableCache === true;
     disableMix = options.disableMix === true;
     transform = options.transform;
+    transformProperty = options.transformProperty;
   }
 
   return function styleq() {
@@ -95,9 +97,19 @@ function createStyleq(options?: StyleqOptions): Styleq {
             if (typeof value === 'string' || value === null) {
               // Only add to chunks if this property hasn't already been seen
               if (!definedProperties.includes(prop)) {
-                definedProperties.push(prop);
-                if (nextCache != null) {
-                  definedPropertiesChunk.push(prop);
+                const propsToDefine = transformProperty
+                  ? transformProperty(prop)
+                  : prop;
+                if (Array.isArray(propsToDefine)) {
+                  definedProperties.push(...propsToDefine);
+                  if (nextCache != null) {
+                    definedPropertiesChunk.push(...propsToDefine);
+                  }
+                } else {
+                  definedProperties.push(propsToDefine);
+                  if (nextCache != null) {
+                    definedPropertiesChunk.push(propsToDefine);
+                  }
                 }
                 if (typeof value === 'string') {
                   classNameChunk += classNameChunk ? ' ' + value : value;
@@ -162,7 +174,14 @@ function createStyleq(options?: StyleqOptions): Styleq {
                   }
                   (subStyle as { ...InlineStyle })[prop] = value;
                 }
-                definedProperties.push(prop);
+                const propsToDefine = transformProperty
+                  ? transformProperty(prop)
+                  : prop;
+                if (Array.isArray(propsToDefine)) {
+                  definedProperties.push(...propsToDefine);
+                } else {
+                  definedProperties.push(propsToDefine);
+                }
                 // Cache is unnecessary overhead if results can't be reused.
                 nextCache = null;
               }

--- a/styleq.js.flow
+++ b/styleq.js.flow
@@ -27,6 +27,7 @@ export type StyleqOptions = {
   disableCache?: boolean,
   disableMix?: boolean,
   transform?: (EitherStyle) => EitherStyle,
+  transformProperty?: (string) => $ReadOnlyArray<string> | string,
 };
 
 export type StyleqResult = [string, InlineStyle | null];

--- a/test/styleq-transform.test.js
+++ b/test/styleq-transform.test.js
@@ -64,7 +64,7 @@ function localizeStyle(style, isRTL) {
   return style;
 }
 
-describe('transform: styles', () => {
+describe('transform', () => {
   let isRTL = false;
   const styleqWithLocalization = styleq.factory({
     transform(style) {
@@ -95,7 +95,7 @@ describe('transform: styles', () => {
     expect(styleRtl).toEqual({ opacity: 1 });
   });
 
-  test('memoizes results', () => {
+  test('supports memoizing results', () => {
     const firstStyle = localizeStyle(fixture, false);
     const secondStyle = localizeStyle(fixture, false);
     expect(firstStyle).toBe(secondStyle);

--- a/test/styleq-transformProperty.test.js
+++ b/test/styleq-transformProperty.test.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Nicolas Gallagher
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { styleq } from '../src/styleq';
+
+const propMap = {
+  marginInlineStart: ['marginInlineStart', 'marginLeft', 'marginRight'],
+  marginInlineEnd: ['marginInlineEnd', 'marginRight', 'marginLeft'],
+  paddingInlineStart: ['paddingInlineStart', 'paddingLeft', 'paddingRight'],
+  paddingInlineEnd: ['paddingInlineEnd', 'paddingRight', 'paddingLeft'],
+  marginLeft: ['marginLeft', 'marginInlineStart', 'marginInlineEnd'],
+  marginRight: ['marginRight', 'marginInlineEnd', 'marginInlineStart'],
+  paddingLeft: ['paddingLeft', 'paddingInlineStart', 'paddingInlineEnd'],
+  paddingRight: ['paddingRight', 'paddingInlineEnd', 'paddingInlineStart']
+};
+
+const transformProperty = (property) => propMap[property] || property;
+
+const styleqWithPropExpansion = styleq.factory({ transformProperty });
+
+describe('transformProperty', () => {
+  test('later overrides multiple earlier', () => {
+    const [className, style] = styleqWithPropExpansion([
+      {
+        $$css: true,
+        display: 'display-1',
+        marginInlineStart: 'marginInlineStart-1',
+        marginInlineEnd: 'marginInlineEnd-1'
+      },
+      {
+        $$css: true,
+        marginLeft: 'marginLeft-2'
+      }
+    ]);
+    expect(className).toEqual('display-1 marginLeft-2');
+    expect(style).toEqual(null);
+  });
+
+  test('sequence of overrides', () => {
+    const [className, style] = styleqWithPropExpansion([
+      {
+        $$css: true,
+        display: 'display-1',
+        marginInlineStart: 'marginInlineStart-1',
+        marginInlineEnd: 'marginInlineEnd-1'
+      },
+      {
+        $$css: true,
+        marginLeft: 'marginLeft-2'
+      },
+      {
+        $$css: true,
+        marginInlineStart: 'marginInlineStart-3'
+      }
+    ]);
+    expect(className).toEqual(
+      'display-1 marginInlineEnd-1 marginInlineStart-3'
+    );
+    expect(style).toEqual(null);
+  });
+
+  test('accounts for inline styles', () => {
+    const [className, style] = styleqWithPropExpansion([
+      {
+        $$css: true,
+        display: 'display-1',
+        marginLeft: 'marginLeft-1',
+        marginRight: 'marginRight-1'
+      },
+      {
+        marginInlineStart: 2
+      }
+    ]);
+    expect(className).toEqual('display-1');
+    expect(style).toEqual({ marginInlineStart: 2 });
+  });
+});


### PR DESCRIPTION
This change allows an additional function to be passed into styleq.factory that transforms an individual prop key, to return one or more prop keys that should be marked as "defined". This PR replaces #15 which had failing tests and no benchmarks.

When caching is disabled (or the first time a merge is performed) using the `transformProperty` function in the large merge benchmark is about 25% slower than when not using the function.
