### PR TITLE
Add support for compiled style debug strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const [ className, inlineStyle ] = styleq(styles.root, { opacity });
 
 The `styleq` function efficiently merges deeply nested arrays of both extracted and inline style objects.
 
-* Compiled styles must set the `$$css` property to `true`.
+* Compiled styles must set the `$$css` property to `true` for production. And may be a string for development.
 * Any style object without the `$$css` property is treated as an **inline style**.
 * Compiled styles must be static for best performance.
 * Compiled style object keys do not need to match CSS property names; any string is allowed.
@@ -47,15 +47,21 @@ const styles = {
   root: {
     // Needed by the runtime
     $$css: true,
-    // Debug classes
-    'debug::file:styles.root': 'debug::file:styles.root',
     // Atomic CSS classes
     display: 'display-flex-class',
     alignItems: 'alignItems-center-class'
-  }
+  },
+  other: {
+    // String values are concatenated and can be used for dev debugging.
+    // Compilers are encouraged to provide file and line info.
+    $$css: 'path/to/file:10,4',
+    // Atomic CSS classes
+    display: 'display-flex-class',
+    alignItems: 'alignItems-center-class'
+  },
 };
 
-const [ className, inlineStyle ] = styleq(styles.root, props.style);
+const [ className, inlineStyle, dataStyleSrc ] = styleq(styles.root, props.style);
 ```
 
 ### styleq.factory(options) => styleq

--- a/styleq.js.flow
+++ b/styleq.js.flow
@@ -8,7 +8,7 @@
  */
 
 export type CompiledStyle = $ReadOnly<{
-  $$css: true,
+  $$css: true | string,
   [key: string]: string,
 }>;
 
@@ -29,7 +29,7 @@ export type StyleqOptions = {
   transform?: (EitherStyle) => EitherStyle,
 };
 
-export type StyleqResult = [string, InlineStyle | null];
+export type StyleqResult = [string, InlineStyle | null, string];
 export type Styleq = (styles: Styles) => StyleqResult;
 
 export type IStyleq = {

--- a/test/styleq.test.js
+++ b/test/styleq.test.js
@@ -250,4 +250,16 @@ describe('styleq()', () => {
     // Both should produce: [ 'a hover$a b', { b: 'b' } ]
     expect(styleqNoMix([a, b, binline])).toEqual(styleqNoMix([a, binline, b]));
   });
+
+  test('supports generating debug strings', () => {
+    const a = { $$css: 'path/to/a:1', a: 'aaa' };
+    const b = { $$css: 'path/to/b:2', b: 'bbb' };
+    const c = { $$css: 'path/to/c:3', b: 'ccc' };
+    const [, , debugString] = styleq([a]);
+    expect(debugString).toBe('path/to/a:1');
+    const [, , dataStyleSrc] = styleq([a, [b, c]]);
+    expect(dataStyleSrc).toBe('path/to/a:1; path/to/b:2; path/to/c:3');
+    const [, , dataStyleSrcNoCache] = styleqNoCache([a, [b, c]]);
+    expect(dataStyleSrcNoCache).toBe('path/to/a:1; path/to/b:2; path/to/c:3');
+  });
 });


### PR DESCRIPTION
The value of `$$css` can be a string. These strings will be concatenated by the runtime, and can be used to populate a `data-*` prop to provide developers with useful debugging information. For example, the source files and line numbers associated with the styles involved in the merge.